### PR TITLE
Reduce eigh

### DIFF
--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -216,3 +216,6 @@ class CMA:
             + self._c1 * rank_one
             + self._cmu * rank_mu
         )
+        D2, B = np.linalg.eigh(self._C)
+        D = np.sqrt(D2)
+        self._B, self._D = B, D

--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -129,6 +129,7 @@ class CMA:
 
     def _sample_solution(self) -> Tuple[np.ndarray, np.ndarray]:
         if self._B is None or self._D is None:
+            self._C = (self._C + self._C.T) / 2
             D2, B = np.linalg.eigh(self._C)
             D = np.sqrt(D2)
             self._B, self._D = B, D
@@ -154,6 +155,7 @@ class CMA:
 
         # Sample new population of search_points, for k=1, ..., popsize
         if self._B is None or self._D is None:
+            self._C = (self._C + self._C.T) / 2
             D2, B = np.linalg.eigh(self._C)  # eigen decomposition for symmetric matrix.
             D = np.sqrt(D2)
         else:
@@ -216,6 +218,7 @@ class CMA:
             + self._c1 * rank_one
             + self._cmu * rank_mu
         )
+        self._C = (self._C + self._C.T) / 2
         D2, B = np.linalg.eigh(self._C)
         D = np.sqrt(D2)
         self._B, self._D = B, D


### PR DESCRIPTION
The current implementation needs eigenvalue decomposition every calling of `_sample_solution`.
This PR fixes the issue.

In addition to the above, symmetrization of the covariance matrix has been added to improve the stability of eigenvalue decomposition.
This is a common technique in this community (e.g. [this code of pycma](https://github.com/CMA-ES/pycma/blob/30f8c330795251c618ca8f48646f733159d55b37/cma/sampler.py#L343)).