### PR TITLE
Reduce the size of pickle serialized object.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,17 @@ jobs:
           pip install --progress-bar off .[lint]
       - run: flake8 . --show-source --statistics
       - run: black --check .
-      - run: mypy .
+      - run: mypy cmaes
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --progress-bar off .[optuna]
+      - run: python setup.py test

--- a/README.md
+++ b/README.md
@@ -102,16 +102,16 @@ See [benchmark](./benchmark) for details.
 
 ### Execution Speed
 
-| trials/params | storage | pycma's sampler | this library |
-| ------------- | ------- | --------------- | ------------ |
-|     100 / 10  |  memory |          6.000s |       0.706s |
-|     500 / 50  |  memory |      4m 52.008s |       2.697s |
-|   1000 / 100  |  memory |     37m 41.617s |       7.690s |
-|     100 / 10  |  sqlite |         16.259s |      12.964s |
-|     500 / 50  |  sqlite |      8m 34.557s |   2m 53.790s |
+| trials/params | storage |      pycma's sampler |         this library |
+| ------------- | ------- | -------------------- | -------------------- |
+|     100 /   5 |  memory |   4.976 (+/- 0.596)s |   0.197 (+/- 0.078)s |
+|     500 /   5 |  memory |  71.651 (+/- 3.847)s |   0.656 (+/- 0.044)s |
+|     500 /  50 |  memory | 291.002 (+/- 5.010)s |   1.981 (+/- 0.041)s |
+|     100 /   5 |  sqlite |  16.143 (+/- 3.487)s |  11.843 (+/- 1.390)s |
+|     500 /   5 |  sqlite | 129.436 (+/- 6.279)s |  43.735 (+/- 2.676)s |
+|     500 /  50 |  sqlite | 397.084 (+/- 6.618)s | 150.531 (+/- 1.113)s |
 
-
-[This script](./benchmark/speed_problem.py) was run on my laptop so the times should not be taken precisely.
+[This script](./benchmark/speed_test.py) was run on my laptop with `--times 4`. So the times should not be taken precisely.
 Even though, it is clear that this library is extremely faster than Optuna's pycma sampler (with Optuna v1.0.0 and pycma v2.7.0).
 
 Links

--- a/benchmark/profile.py
+++ b/benchmark/profile.py
@@ -1,13 +1,13 @@
 import argparse
 import cProfile
 import logging
+import pstats
 import optuna
 
 from optuna.integration.cma import CmaEsSampler
 from cmaes.sampler import CMASampler
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--profile", type=int, default=0)
 parser.add_argument("--storage", choices=["memory", "sqlite"], default="memory")
 parser.add_argument("--params", type=int, default=100)
 parser.add_argument("--trials", type=int, default=1000)
@@ -33,14 +33,15 @@ def main():
     else:
         sampler = CMASampler()
     study = optuna.create_study(sampler=sampler, storage=storage)
-    if args.profile:
-        profiler = cProfile.Profile()
-        profiler.runcall(
-            study.optimize, objective, n_trials=args.trials, gc_after_trial=False
-        )
-        profiler.dump_stats("profile.stats")
-    else:
-        study.optimize(objective, n_trials=args.trials, gc_after_trial=False)
+
+    profiler = cProfile.Profile()
+    profiler.runcall(
+        study.optimize, objective, n_trials=args.trials, gc_after_trial=False
+    )
+    profiler.dump_stats("profile.stats")
+
+    stats = pstats.Stats("profile.stats")
+    stats.sort_stats('time').print_stats(5)
 
 
 if __name__ == "__main__":

--- a/benchmark/speed_test.py
+++ b/benchmark/speed_test.py
@@ -1,0 +1,79 @@
+import argparse
+import logging
+import time
+import optuna
+import numpy as np
+
+from optuna.integration.cma import CmaEsSampler
+from cmaes.sampler import CMASampler
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--times", type=int, default=1)
+args = parser.parse_args()
+
+
+def run_optimize(sampler_str, storage_str, trials, params, index):
+    storage = None
+    if storage_str == "sqlite":
+        storage = f"sqlite:///db_{sampler_str}_{params}_{trials}_{index}.sqlite3"
+
+    if sampler_str == "pycma":
+        sampler = CmaEsSampler()
+    else:
+        sampler = CMASampler()
+    study = optuna.create_study(sampler=sampler, storage=storage)
+
+    def objective(trial: optuna.Trial):
+        val = 0
+        for i in range(params):
+            xi = trial.suggest_uniform(str(i), -4, 4)
+            val += (xi - 2) ** 2
+        return val
+
+    start = time.time()
+    study.optimize(objective, n_trials=trials, gc_after_trial=False)
+    return time.time() - start
+
+
+def print_markdown_table(results):
+    print(f"The benchmark is executed {args.times} times.")
+    print("")
+    # Header
+    print("| trials/params | storage | pycma's sampler | this library |")
+    print("| ------------- | ------- | --------------- | ------------ |")
+
+    for trials_params, storage, pycma_score, cmaes_score in results:
+        print(f"| {trials_params} | {storage} | {pycma_score} | {cmaes_score} |")
+
+
+def main():
+    results = []
+    for storage, trials, params in [
+        ("memory", 100, 5),
+        ("sqlite", 100, 5),
+        ("memory", 500, 5),
+        ("sqlite", 500, 5),
+        ("memory", 500, 50),
+        ("sqlite", 500, 50),
+    ]:
+        print("Started:", storage, trials, params)
+
+        elapsed = []
+        for i in range(args.times):
+            elapsed.append(run_optimize("pycma", storage, trials, params, i))
+        pycma_score = f"{np.mean(elapsed):.3f} (+/- {np.std(elapsed):.3f})s"
+
+        elapsed = []
+        for i in range(args.times):
+            elapsed.append(run_optimize("cmaes", storage, trials, params, i))
+        cmaes_score = f"{np.mean(elapsed):7.3f} (+/- {np.std(elapsed):.3f})s"
+
+        results.append((f"{trials:3} / {params:3}", storage, pycma_score, cmaes_score))
+
+    print_markdown_table(results)
+
+
+if __name__ == "__main__":
+    logging.disable(level=logging.INFO)
+
+    main()

--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -254,11 +254,9 @@ def _compress_symmetric(sym2d: np.ndarray) -> np.ndarray:
 
 def _decompress_symmetric(sym1d: np.ndarray) -> np.ndarray:
     n = int(np.sqrt(sym1d.size * 2))
-    if (n * (n + 1)) // 2 != sym1d.size:
-        return None
-    else:
-        R, C = np.triu_indices(n)
-        out = np.zeros((n, n), dtype=sym1d.dtype)
-        out[R, C] = sym1d
-        out[C, R] = sym1d
+    assert (n * (n + 1)) // 2 == sym1d.size
+    R, C = np.triu_indices(n)
+    out = np.zeros((n, n), dtype=sym1d.dtype)
+    out[R, C] = sym1d
+    out[C, R] = sym1d
     return out

--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -113,9 +113,21 @@ class CMA:
         self._rng = np.random.RandomState(seed)
 
     def __getstate__(self) -> Dict[str, Any]:
-        return {attr: getattr(self, attr) for attr in self.__dict__ if attr != "_rng"}
+        attrs = {}
+        for name in self.__dict__:
+            # Remove _rng in pickle serialized object.
+            if name == "_rng":
+                continue
+            if name == "_C":
+                sym1d = _compress_symmetric(self._C)
+                attrs["_c_1d"] = sym1d
+                continue
+            attrs[name] = getattr(self, name)
+        return attrs
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
+        state["_C"] = _decompress_symmetric(state["_c_1d"])
+        del state["_c_1d"]
         self.__dict__.update(state)
         # Set _rng for unpickled object.
         setattr(self, "_rng", np.random.RandomState())
@@ -226,3 +238,27 @@ class CMA:
             + self._c1 * rank_one
             + self._cmu * rank_mu
         )
+
+
+def _compress_symmetric(sym2d: np.ndarray) -> np.ndarray:
+    assert len(sym2d.shape) == 2 and sym2d.shape[0] == sym2d.shape[1]
+    n = sym2d.shape[0]
+    dim = (n * (n + 1)) // 2
+    sym1d = np.zeros(dim)
+    start = 0
+    for i in range(n):
+        sym1d[start : start + n - i] = sym2d[i][i:]  # noqa: E203
+        start += n - i
+    return sym1d
+
+
+def _decompress_symmetric(sym1d: np.ndarray) -> np.ndarray:
+    n = int(np.sqrt(sym1d.size * 2))
+    if (n * (n + 1)) // 2 != sym1d.size:
+        return None
+    else:
+        R, C = np.triu_indices(n)
+        out = np.zeros((n, n), dtype=sym1d.dtype)
+        out[R, C] = sym1d
+        out[C, R] = sym1d
+    return out

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,12 @@ setup(
         "benchmark": ["kurobako", "cma", "optuna"],
         "visualization": ["matplotlib", "scipy"],
         "lint": ["mypy", "flake8", "black", "optuna"],
+        "test": ["optuna"],
         "release": ["wheel", "twine"],
     },
     tests_require=[],
     keywords="cma-es evolution-strategy optuna",
     license="MIT License",
     include_package_data=True,
+    test_suite="tests",
 )

--- a/tests/test_compress_symmetric.py
+++ b/tests/test_compress_symmetric.py
@@ -1,0 +1,29 @@
+import numpy as np
+from unittest import TestCase
+from cmaes.cma import _decompress_symmetric, _compress_symmetric
+
+
+class TestCompressSymmetric(TestCase):
+    def test_compress_symmetric_odd(self):
+        sym2d = np.array([[1, 2], [2, 3]])
+        actual = _compress_symmetric(sym2d)
+        expected = np.array([1, 2, 3])
+        self.assertTrue(np.all(np.equal(actual, expected)))
+
+    def test_compress_symmetric_even(self):
+        sym2d = np.array([[1, 2, 3], [2, 4, 5], [3, 5, 6]])
+        actual = _compress_symmetric(sym2d)
+        expected = np.array([1, 2, 3, 4, 5, 6])
+        self.assertTrue(np.all(np.equal(actual, expected)))
+
+    def test_decompress_symmetric_odd(self):
+        sym1d = np.array([1, 2, 3])
+        actual = _decompress_symmetric(sym1d)
+        expected = np.array([[1, 2], [2, 3]])
+        self.assertTrue(np.all(np.equal(actual, expected)))
+
+    def test_decompress_symmetric_even(self):
+        sym1d = np.array([1, 2, 3, 4, 5, 6])
+        actual = _decompress_symmetric(sym1d)
+        expected = np.array([[1, 2, 3], [2, 4, 5], [3, 5, 6]])
+        self.assertTrue(np.all(np.equal(actual, expected)))


### PR DESCRIPTION
After my investigation at https://github.com/c-bata/cmaes/pull/11.

Compressing the covariance matrix makes the size of the pickle serialized CMA object almost half size. But the performance is a bit worse, especially in the low-dimensional search space.

## Size

```
import sys
x = {attr: sys.getsizeof(pickle.dumps(getattr(optimizer, attr))) for attr in optimizer.__dict__}
```

```
{'_n_dim': 38, '_popsize': 38, '_mu': 38, '_mu_eff': 151,
 '_cc': 151, '_c1': 151, '_cmu': 151, '_c_sigma': 151, '_d_sigma': 151,
 '_cm': 38, '_chi_n': 54, '_weights': 302, '_p_sigma': 585, '_pc': 585,
 '_mean': 585, '_C': 20187, '_sigma': 151, '_D': 37, '_B': 37, '_bounds': 987,
 '_n_max_resampling': 48, '_g': 38, '_rng': 2823}
```

Before

`python benchmark/speed_problem.py --storage sqlite --sampler cmaes --trials 100 --params 100`

```
(Pdb) p x
{'_n_dim': 38, '_popsize': 38, '_mu': 38, '_mu_eff': 151, '_cc': 151, '_c1': 151, '_cmu': 151, '_c_sigma': 151, '_d_sigma': 151, '_cm': 38, '_chi_n': 54, '_weights': 318, '_p_sigma': 985, '_pc': 985, '_mean': 985, '_C': 80196, '_sigma': 151, '_D': 37, '_B': 37, '_bounds': 1787, '_n_max_resampling': 48, '_g': 38, '_rng': 2823}
(Pdb) p sum(x.values())
89502
(Pdb) p sys.getsizeof(pickled_optimizer)
84915
```

After

```
(Pdb) p x
{'_n_dim': 38, '_popsize': 38, '_mu': 38, '_mu_eff': 151, '_cc': 151, '_c1': 151, '_cmu': 151, '_c_sigma': 151, '_d_sigma': 151, '_cm': 38, '_chi_n': 54, '_weights': 318, '_p_sigma': 985, '_pc': 985, '_mean': 985, '_C': 80196, '_sigma': 151, '_D': 37, '_B': 37, '_bounds': 1787, '_n_max_resampling': 48, '_g': 38, '_rng': 2823}
(Pdb) p sum(x.values())
89502
(Pdb) p sys.getsizeof(pickled_optimizer)
45308
```

## Speed test

Before

| params | timeout |  storage | num_trials |
| ------ | ------- |  ------- | ------------ |
|      5 |      5s | memory | 2941.333 |
|     50 |     10s | memory |  2226.667 |
|      5 |      5s | sqlite |  63.000 |
|      5 |     50s | sqlite |   605.333 |
|     50 |     50s | sqlite | 165.000 |


After

| params | timeout |  storage | num_trials |
| ------ | ------- |  ------- | ------------ |
|      5 |      5s | memory | 2888.667 |
|     50 |     10s | memory |  1889.333 |
|      5 |      5s | sqlite |  37.000 |
|      5 |     50s | sqlite |   593.667 |
|     50 |     50s | sqlite | 167.000 |

The benchmark is executed 3 times. The performance is a bit worse, especially in the low-dimensional search space (5 params). But the performance is a bit improve, especially in the high-dimensional search space (50 params).