### PR TITLE
Python 3.5 support.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,23 @@
+name: Python application
+
+on: [push]
+
+jobs:
+  examples:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --progress-bar off .
+          pip install --progress-bar off optuna
+      - run: python examples/quadratic_function.py
+      - run: python examples/optuna_sampler.py

--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -102,8 +102,8 @@ class CMA:
         self._mean = mean
         self._C = np.eye(n_dim)
         self._sigma = sigma
-        self._D: Optional[np.ndarray] = None
-        self._B: Optional[np.ndarray] = None
+        self._D = None  # type: Optional[np.ndarray]
+        self._B = None  # type: Optional[np.ndarray]
 
         # bounds contains low and high of each parameter.
         self._bounds = bounds  # (n_dim, 2)-dim matrix

--- a/cmaes/sampler.py
+++ b/cmaes/sampler.py
@@ -140,9 +140,9 @@ class CMASampler(BaseSampler):
     ) -> CMA:
         # Restore a previous CMA object.
         for trial in reversed(completed_trials):
-            serialized_optimizer: Union[str, bytes, None] = trial.system_attrs.get(
+            serialized_optimizer = trial.system_attrs.get(
                 "cma:optimizer", None
-            )
+            )  # type: Union[str, bytes, None]
             if serialized_optimizer is None:
                 continue
             if isinstance(serialized_optimizer, bytes):
@@ -295,7 +295,7 @@ def _distribution_to_dict(dist: BaseDistribution) -> Dict[str, Any]:
 def _fast_intersection_search_space(
     study: optuna.Study, trial_id: int
 ) -> Dict[str, BaseDistribution]:
-    search_space: Optional[Dict[str, BaseDistribution]] = None
+    search_space = None  # type: Optional[Dict[str, BaseDistribution]]
 
     for trial in reversed(study.get_trials(deepcopy=False)):
         if trial.state != optuna.structs.TrialState.COMPLETE:
@@ -316,7 +316,7 @@ def _fast_intersection_search_space(
             del search_space[param_name]
 
         # Retrieve cache from trial_system_attrs.
-        json_str: str = trial.system_attrs.get("cma:search_space", None)
+        json_str= trial.system_attrs.get("cma:search_space", None)  # type: str
         if json_str is None:
             continue
         json_dict = json.loads(json_str)

--- a/cmaes/sampler.py
+++ b/cmaes/sampler.py
@@ -316,7 +316,7 @@ def _fast_intersection_search_space(
             del search_space[param_name]
 
         # Retrieve cache from trial_system_attrs.
-        json_str= trial.system_attrs.get("cma:search_space", None)  # type: str
+        json_str = trial.system_attrs.get("cma:search_space", None)  # type: str
         if json_str is None:
             continue
         json_dict = json.loads(json_str)

--- a/examples/quadratic_function.py
+++ b/examples/quadratic_function.py
@@ -15,7 +15,9 @@ def main():
             x = cma_es.ask()
             value = quadratic(x[0], x[1])
             solutions.append((x, value))
-            print(f"#{generation} {value} (x1={x[0]}, x2 = {x[1]})")
+            print("#{g} {value} (x1={x1}, x2 = {x2})".format(
+                g=generation, value=value, x1=x[0], x2=x[1],
+            ))
         cma_es.tell(solutions)
 
 

--- a/examples/quadratic_function.py
+++ b/examples/quadratic_function.py
@@ -8,6 +8,8 @@ def quadratic(x1, x2):
 
 def main():
     cma_es = CMA(mean=np.zeros(2), sigma=1.3)
+    print(" g    f(x1,x2)     x1      x2  ")
+    print("===  ==========  ======  ======")
 
     for generation in range(50):
         solutions = []
@@ -15,9 +17,11 @@ def main():
             x = cma_es.ask()
             value = quadratic(x[0], x[1])
             solutions.append((x, value))
-            print("#{g} {value} (x1={x1}, x2 = {x2})".format(
+
+            msg = "{g:3d}  {value:10.5f}  {x1:6.2f}  {x2:6.2f}".format(
                 g=generation, value=value, x1=x[0], x2=x[1],
-            ))
+            )
+            print(msg)
         cma_es.tell(solutions)
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Add Python 3.5 support to add integration in Optuna.

* Avoid using variable annotation syntax for type hints.
* Avoid using f-string.
* Run Python 3.5 examples on CI.
    * See the results of https://github.com/c-bata/cmaes/pull/15