### PR TITLE
change to avoid eigendecomposition error

### DIFF
--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -314,7 +314,7 @@ class CMA:
             + self._cmu * rank_mu
         )
         # Avoid eigendecomposition error by arithmetic overflow
-        self._C += 1e-16
+        self._C += np.diag(np.ones(self._n_dim) * 1e-16)
 
 
 def _compress_symmetric(sym2d: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
The current implementation adds the small value (1e-16) to every element of the covariance matrix to prevent eigenvalue decomposition errors.
However, in order to maintain positive definiteness, it is enough to add the small value only to the diagonal components, which is more intuitive.