### PR TITLE
Monkeypatch for faster intersection search space

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,31 @@ See [the documentation](https://optuna.readthedocs.io/en/stable/reference/sample
 
 <details>
 
+<summary>Monkeypatch for faster CMA-ES sampler of Optuna v1.3.x.</summary>
+
+If you are using Optuna v1.3.x, you can make `optuna.samplers.CmaEsSampler` faster.
+
+```python
+import optuna
+from cmaes.monkeypatch import patch_fast_intersection_search_space
+
+patch_fast_intersection_search_space()
+
+def objective(trial: optuna.Trial):
+    x1 = trial.suggest_uniform("x1", -4, 4)
+    x2 = trial.suggest_uniform("x2", -4, 4)
+    return (x1 - 3) ** 2 + (10 * (x2 + 2)) ** 2
+
+if __name__ == "__main__":
+    sampler = optuna.samplers.CmaEsSampler()
+    study = optuna.create_study(sampler=sampler)
+    study.optimize(objective, n_trials=250)
+```
+
+</details>
+
+<details>
+
 <summary>For older versions (Optuna v1.2.0 or older)</summary>
 
 If you are using older versions, please use `cmaes.samlper.CMASampler`.

--- a/cmaes/monkeypatch.py
+++ b/cmaes/monkeypatch.py
@@ -1,0 +1,26 @@
+from typing import Tuple
+
+try:
+    import optuna
+except:  # noqa: E722
+    optuna = None
+
+
+def get_optuna_version() -> Tuple[int, int]:
+    optuna_ver_info = optuna.__version__.split(".")
+    major_ver, minor_ver = int(optuna_ver_info[0]), int(optuna_ver_info[1])
+    return major_ver, minor_ver
+
+
+def patch_fast_intersection_search_space() -> None:
+    if optuna is None:
+        return
+
+    # TODO(c-bata): Set the upper version constraint after merged to Optuna.
+    # https://github.com/optuna/optuna/pull/885
+    if get_optuna_version() < (1, 3):
+        return
+
+    from .sampler import _fast_intersection_search_space
+
+    optuna.samplers.intersection_search_space = _fast_intersection_search_space

--- a/examples/monkeypatch.py
+++ b/examples/monkeypatch.py
@@ -1,0 +1,21 @@
+import optuna
+from cmaes.monkeypatch import patch_fast_intersection_search_space
+
+patch_fast_intersection_search_space()
+
+
+def objective(trial: optuna.Trial):
+    x1 = trial.suggest_uniform("x1", -4, 4)
+    x2 = trial.suggest_uniform("x2", -4, 4)
+    return (x1 - 3) ** 2 + (10 * (x2 + 2)) ** 2
+
+
+def main():
+    optuna.logging.set_verbosity(optuna.logging.INFO)
+    sampler = optuna.samplers.CmaEsSampler()
+    study = optuna.create_study(sampler=sampler)
+    study.optimize(objective, n_trials=1000, gc_after_trial=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Backports of https://github.com/optuna/optuna/pull/885

```python
import optuna
from cmaes.monkeypatch import patch_fast_intersection_search_space

patch_fast_intersection_search_space()

def objective(trial: optuna.Trial):
    x1 = trial.suggest_uniform("x1", -4, 4)
    x2 = trial.suggest_uniform("x2", -4, 4)
    return (x1 - 3) ** 2 + (10 * (x2 + 2)) ** 2


def main():
    optuna.logging.set_verbosity(optuna.logging.INFO)
    sampler = optuna.samplers.CmaEsSampler()
    study = optuna.create_study(sampler=sampler)
    study.optimize(objective, n_trials=1000, gc_after_trial=False)


if __name__ == "__main__":
    main()
```

## Check the performance

**Before (without patch_fast_intersection_search_space)**

0m55.712s

**After (with patch_fast_intersection_search_space)**

0m29.618s