### PR TITLE
Avoid zero deviation error and eigendecomposition error

### DIFF
--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -315,7 +315,7 @@ class CMA:
             + self._cmu * rank_mu
         )
         # Avoid eigendecomposition error by arithmetic overflow
-        self._C += 1e-16
+        self._C += np.diag(np.ones(self._n_dim) * 1e-16)
 
 
 def _compress_symmetric(sym2d: np.ndarray) -> np.ndarray:

--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -259,6 +259,7 @@ class CMA:
 
         x_k = np.array([s[0] for s in solutions])  # ~ N(m, σ^2 C)
         y_k = (x_k - self._mean) / self._sigma  # ~ N(0, C)
+        y_k += 1e-16  # Avoid zero deviation error at eq.46
 
         # Selection and recombination
         y_w = np.sum(y_k[: self._mu].T * self._weights[: self._mu], axis=1)  # eq.41


### PR DESCRIPTION
```python
import numpy as np
from cmaes import CMA


def quadratic(x1, x2):
    return (x1 - 3) ** 2 + (10 * (x2 + 2)) ** 2


def main():
    cma_es = CMA(mean=np.zeros(2), sigma=1.3, seed=0)
    print(" g    f(x1,x2)     x1      x2  ")
    print("===  ==========  ======  ======")

    for generation in range(200):
        solutions = []
        for _ in range(cma_es.population_size):
            x = cma_es.ask()
            value = quadratic(x[0], x[1])
            solutions.append((x, value))

            msg = "{g:3d}  {value:10.5f}  {x1:6.2f}  {x2:6.2f}".format(
                g=generation, value=value, x1=x[0], x2=x[1],
            )
            print(msg)
        cma_es.tell(solutions)


if __name__ == "__main__":
    main()

```

```
(venv) $ python examples/quadratic_function.py 
 g    f(x1,x2)     x1      x2  
===  ==========  ======  ======
  0   635.64248    2.29    0.52
  0  2416.90000    1.27    2.91
  0    53.55006    2.43   -1.27
  0   328.28069    1.24   -0.20
...
199     0.00000    3.00   -2.00
199     0.00000    3.00   -2.00
199     0.00000    3.00   -2.00
199     0.00000    3.00   -2.00
```