### PR TITLE
Avoid numerical errors and overflow.

### DIFF
--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -1,4 +1,5 @@
 import math
+import sys
 import numpy as np
 
 from typing import Any
@@ -284,10 +285,7 @@ class CMA:
         # To avoid overflow
         _log_sigma = np.log(self._sigma + self._epsilon) + (self._c_sigma / self._d_sigma) * (
                 norm_p_sigma / self._chi_n - 1)
-        if _log_sigma > 10 ** 2.8:
-            self._sigma = np.exp(10 ** 2.8)
-        else:
-            self._sigma = np.exp(_log_sigma)
+        self._sigma = min(np.exp(_log_sigma), sys.float_info.max)
 
         # Covariance matrix adaption
         h_sigma_cond_left = norm_p_sigma / math.sqrt(


### PR DESCRIPTION
## Motivation
In the current implementation of `CMA` class, 
- we calculate eigenvalues and vectors by using `numpy.linalg.eigh`, and then take a route for eigenvalues, and
- we take `numpy.exp` each time the `tell` function is called.

For the first, due to the numerical error in `numpy.linalg.eigh`, the eigenvalue may be negative and the result of the root may be Nan. As for the second, `numpy.exp` may overflow when the variance of the objective function is very large. This PR aims to resolve the above problems.

## Description of the changes
- If an eigenvalue becomes negative due to a numerical error, it is corrected to a small positive number (CMA._epsilon).
- If it is large enough to overflow, replace it with a value that does not overflow.