### PR TITLE
Add should_stop() method for IPOP-CMA-ES.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -26,4 +26,5 @@ jobs:
           pip install --progress-bar off optuna
           pip install --progress-bar off -U .
       - run: python examples/quadratic_function.py
+      - run: python examples/ipop_cmaes.py
       - run: python examples/optuna_sampler.py

--- a/README.md
+++ b/README.md
@@ -92,21 +92,30 @@ You can easily implement IPOP-CMA-ES which restarts CMA-ES
 with increasing population size.
 
 ```python
+import math
 import numpy as np
 from cmaes import CMA
 
-def quadratic(x1, x2):
-    return (x1 - 3) ** 2 + (10 * (x2 + 2)) ** 2
+
+def ackley(x1, x2):
+    # https://www.sfu.ca/~ssurjano/ackley.html
+    return (
+        -20 * math.exp(-0.2 * math.sqrt(0.5 * (x1 ** 2 + x2 ** 2)))
+        - math.exp(0.5 * (math.cos(2 * math.pi * x1) + math.cos(2 * math.pi * x2)))
+        + math.e + 20
+    )
+
 
 if __name__ == "__main__":
-    cma_opts = {"mean": np.zeros(2), "sigma": 1.3}
-    optimizer = CMA(**cma_opts)
+    bounds = np.array([[-32.768, 32.768], [-32.768, 32.768]])
+    sigma = (np.max(bounds) - np.min(bounds)) / 5  # 1/5 of the domain width
+    optimizer = CMA(mean=np.random.randn(2), sigma=sigma)
 
-    for generation in range(150):
+    for generation in range(200):
         solutions = []
         for _ in range(optimizer.population_size):
             x = optimizer.ask()
-            value = quadratic(x[0], x[1])
+            value = ackley(x[0], x[1])
             solutions.append((x, value))
             print(f"#{generation} {value} (x1={x[0]}, x2 = {x[1]})")
         optimizer.tell(solutions)
@@ -114,7 +123,7 @@ if __name__ == "__main__":
         if optimizer.should_stop():
             # popsize multiplied by 2 (or 3) before each restart.
             popsize = optimizer.population_size * 2
-            optimizer = CMA(population_size=popsize, **cma_opts)
+            optimizer = CMA(mean=np.random.randn(2), sigma=sigma, population_size=popsize)
             print(f"Restart CMA-ES with popsize={popsize}")
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,41 @@ if __name__ == "__main__":
     study.optimize(objective, n_trials=250)
 ```
 
+<details>
+<summary>Example of IPOP-CMA-ES [3]</summary>
+
+You can easily implement IPOP-CMA-ES which restarts CMA-ES
+with increasing population size.
+
+```python
+import numpy as np
+from cmaes import CMA
+
+def quadratic(x1, x2):
+    return (x1 - 3) ** 2 + (10 * (x2 + 2)) ** 2
+
+if __name__ == "__main__":
+    cma_opts = {"mean": np.zeros(2), "sigma": 1.3}
+    optimizer = CMA(**cma_opts)
+
+    for generation in range(150):
+        solutions = []
+        for _ in range(optimizer.population_size):
+            x = optimizer.ask()
+            value = quadratic(x[0], x[1])
+            solutions.append((x, value))
+            print(f"#{generation} {value} (x1={x[0]}, x2 = {x[1]})")
+        optimizer.tell(solutions)
+
+        if optimizer.should_terminate():
+            # popsize multiplied by 2 (or 3) before each restart.
+            popsize = optimizer.population_size * 2
+            optimizer = CMA(population_size=popsize, **cma_opts)
+            print(f"Restart CMA-ES with popsize={popsize}")
+```
+
+</details>
+
 ## Benchmark results
 
 | [Rosenbrock function](https://www.sfu.ca/~ssurjano/rosen.html) | [Six-Hump Camel function](https://www.sfu.ca/~ssurjano/camel6.html) |
@@ -108,4 +143,4 @@ I respect all libraries involved in CMA-ES.
 
 * [1] [N. Hansen, The CMA Evolution Strategy: A Tutorial. arXiv:1604.00772, 2016.](https://arxiv.org/abs/1604.00772)
 * [2] [Takuya Akiba, Shotaro Sano, Toshihiko Yanase, Takeru Ohta, Masanori Koyama. 2019. Optuna: A Next-generation Hyperparameter Optimization Framework. In The 25th ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD ’19), August 4–8, 2019.](https://dl.acm.org/citation.cfm?id=3330701)
-
+* [3] [Auger, A., Hansen, N.: A restart CMA evolution strategy with increasing population size. In: Proceedings of the 2005 IEEE Congress on Evolutionary Computation (CEC’2005), pp. 1769–1776 (2005a)](https://sci2s.ugr.es/sites/default/files/files/TematicWebSites/EAMHCO/contributionsCEC05/auger05ARCMA.pdf)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ if __name__ == "__main__":
             print(f"#{generation} {value} (x1={x[0]}, x2 = {x[1]})")
         optimizer.tell(solutions)
 
-        if optimizer.should_terminate():
+        if optimizer.should_stop():
             # popsize multiplied by 2 (or 3) before each restart.
             popsize = optimizer.population_size * 2
             optimizer = CMA(population_size=popsize, **cma_opts)

--- a/cmaes/_cma.py
+++ b/cmaes/_cma.py
@@ -369,6 +369,18 @@ class CMA:
         if self._sigma * np.max(D) > self._tolxup:
             return True
 
+        # No effect coordinates: stop if adding 0.2-standard deviations
+        # in any single coordinate does not change m.
+        if np.any(self._mean == self._mean + (0.2 * self._sigma * np.sqrt(dC))):
+            return True
+
+        # No effect axis: stop if adding 0.1-standard deviation vector in
+        # any principal axis direction of C does not change m. "pycma" check
+        # axis one by one at each generation.
+        i = self.generation % self.dim
+        if np.all(self._mean == self._mean + (0.1 * self._sigma * D[i] * B[:, i])):
+            return True
+
         # Stop if the condition number of the covariance matrix exceeds 1e14.
         condition_cov = np.max(D) / np.min(D)
         if condition_cov > self._tolconditioncov:

--- a/cmaes/_cma.py
+++ b/cmaes/_cma.py
@@ -54,6 +54,9 @@ class CMA:
 
         seed:
             A seed number (optional).
+
+        population_size:
+            A population size (optional).
     """
 
     def __init__(
@@ -63,18 +66,25 @@ class CMA:
         bounds: Optional[np.ndarray] = None,
         n_max_resampling: int = 100,
         seed: Optional[int] = None,
+        population_size: Optional[int] = None,
     ):
         assert sigma > 0, "sigma must be non-zero positive value"
 
         n_dim = len(mean)
         assert n_dim > 1, "The dimension of mean must be larger than 1"
 
-        popsize = 4 + math.floor(3 * math.log(n_dim))  # (eq. 48)
-        mu = popsize // 2
+        if population_size is None:
+            population_size = 4 + math.floor(3 * math.log(n_dim))  # (eq. 48)
+        assert population_size > 0, "popsize must be non-zero positive value."
+
+        mu = population_size // 2
 
         # (eq.49)
         weights_prime = np.array(
-            [math.log((popsize + 1) / 2) - math.log(i + 1) for i in range(popsize)]
+            [
+                math.log((population_size + 1) / 2) - math.log(i + 1)
+                for i in range(population_size)
+            ]
         )
         mu_eff = (np.sum(weights_prime[:mu]) ** 2) / np.sum(weights_prime[:mu] ** 2)
         mu_eff_minus = (np.sum(weights_prime[mu:]) ** 2) / np.sum(
@@ -122,7 +132,7 @@ class CMA:
         assert cc <= 1, "invalid learning rate for cumulation for the rank-one update"
 
         self._n_dim = n_dim
-        self._popsize = popsize
+        self._popsize = population_size
         self._mu = mu
         self._mu_eff = mu_eff
 
@@ -159,6 +169,15 @@ class CMA:
 
         self._g = 0
         self._rng = np.random.RandomState(seed)
+
+        # Termination criteria
+        self._tolx = 1e-11
+        self._tolxup = 1e4
+        self._tolfun = 1e-11
+        self._tolconditioncov = 1e14
+
+        self._funhist_term = 10 + math.ceil(30 * n_dim / population_size)
+        self._funhist_values = np.empty(self._funhist_term * 2)
 
         # for avoid numerical errors
         self._epsilon = 1e-8
@@ -216,19 +235,22 @@ class CMA:
         x = self._repair_infeasible_params(x)
         return x
 
-    def _sample_solution(self) -> np.ndarray:
-        if self._B is None or self._D is None:
-            self._C = (self._C + self._C.T) / 2
-            D2, B = np.linalg.eigh(self._C)
-            # To avoid taking a route to a negative number due to numerical error
-            D = np.sqrt(np.where(D2 < 0, self._epsilon, D2))
-            # for avoid numerical errors
-            self._B, self._D = B, D
-            BD2 = np.dot(B, np.diag(D ** 2))
-            self._C = np.dot(BD2, B.T)
+    def _eigen_decomposition(self) -> Tuple[np.ndarray, np.ndarray]:
+        if self._B is not None and self._D is not None:
+            return self._B, self._D
 
+        self._C = (self._C + self._C.T) / 2
+        D2, B = np.linalg.eigh(self._C)
+        D = np.sqrt(np.where(D2 < 0, self._epsilon, D2))
+        self._C = np.dot(np.dot(B, np.diag(D ** 2)), B.T)
+
+        self._B, self._D = B, D
+        return B, D
+
+    def _sample_solution(self) -> np.ndarray:
+        B, D = self._eigen_decomposition()
         z = self._rng.randn(self._n_dim)  # ~ N(0, I)
-        y = self._B.dot(np.diag(self._D)).dot(z)  # ~ N(0, C)
+        y = B.dot(np.diag(D)).dot(z)  # ~ N(0, C)
         x = self._mean + self._sigma * y  # ~ N(m, σ^2 C)
         return x
 
@@ -256,14 +278,14 @@ class CMA:
         self._g += 1
         solutions.sort(key=lambda s: s[1])
 
+        # Stores 'best' and 'worst' values of the
+        # last 'self._funhist_term' generations.
+        funhist_idx = 2 * (self.generation % self._funhist_term)
+        self._funhist_values[funhist_idx] = solutions[0][1]
+        self._funhist_values[funhist_idx + 1] = solutions[-1][1]
+
         # Sample new population of search_points, for k=1, ..., popsize
-        if self._B is None or self._D is None:
-            self._C = (self._C + self._C.T) / 2
-            D2, B = np.linalg.eigh(self._C)
-            # To avoid taking a route to a negative number due to numerical error
-            D = np.sqrt(np.where(D2 < 0, self._epsilon, D2))
-        else:
-            B, D = self._B, self._D
+        B, D = self._eigen_decomposition()
         self._B, self._D = None, None
 
         x_k = np.array([s[0] for s in solutions])  # ~ N(m, σ^2 C)
@@ -323,6 +345,35 @@ class CMA:
             + self._c1 * rank_one
             + self._cmu * rank_mu
         )
+
+    def should_terminate(self) -> bool:
+        B, D = self._eigen_decomposition()
+        dC = np.diag(self._C)
+
+        # objective function values
+        if (
+            self.generation > self._funhist_term
+            and np.max(self._funhist_values) - np.min(self._funhist_values)
+            < self._tolfun
+        ):
+            return True
+
+        # TolX
+        if np.all(self._sigma * dC < self._tolx) and np.all(
+            self._sigma * self._pc < self._tolx
+        ):
+            return True
+
+        # TolXUp for divergent behavior
+        if self._sigma * np.max(D) > self._tolxup:
+            return True
+
+        # Condition number of the covariance matrix.
+        condition_cov = np.max(D) / np.min(D)
+        if condition_cov > self._tolconditioncov:
+            return True
+
+        return False
 
 
 def _compress_symmetric(sym2d: np.ndarray) -> np.ndarray:

--- a/examples/ipop_cmaes.py
+++ b/examples/ipop_cmaes.py
@@ -28,7 +28,7 @@ def main():
             print(msg)
         optimizer.tell(solutions)
 
-        if optimizer.should_terminate():
+        if optimizer.should_stop():
             popsize = optimizer.population_size * inc_popsize
             optimizer = CMA(population_size=popsize, **cma_opts)
             print("Restart CMA-ES with popsize={}".format(popsize))

--- a/examples/ipop_cmaes.py
+++ b/examples/ipop_cmaes.py
@@ -7,11 +7,15 @@ def quadratic(x1, x2):
 
 
 def main():
-    optimizer = CMA(mean=np.zeros(2), sigma=1.3)
+    cma_opts = {"mean": np.zeros(2), "sigma": 1.3}
+    optimizer = CMA(**cma_opts)
+
+    # Multiplier for increasing population size before each restart.
+    inc_popsize = 2
+
     print(" g    f(x1,x2)     x1      x2  ")
     print("===  ==========  ======  ======")
-
-    while True:
+    for generation in range(150):
         solutions = []
         for _ in range(optimizer.population_size):
             x = optimizer.ask()
@@ -19,13 +23,15 @@ def main():
             solutions.append((x, value))
 
             msg = "{g:3d}  {value:10.5f}  {x1:6.2f}  {x2:6.2f}".format(
-                g=optimizer.generation, value=value, x1=x[0], x2=x[1],
+                g=generation, value=value, x1=x[0], x2=x[1],
             )
             print(msg)
         optimizer.tell(solutions)
 
         if optimizer.should_terminate():
-            break
+            popsize = optimizer.population_size * inc_popsize
+            optimizer = CMA(population_size=popsize, **cma_opts)
+            print("Restart CMA-ES with popsize={}".format(popsize))
 
 
 if __name__ == "__main__":

--- a/examples/ipop_cmaes.py
+++ b/examples/ipop_cmaes.py
@@ -1,25 +1,38 @@
+import math
 import numpy as np
 from cmaes import CMA
 
 
-def quadratic(x1, x2):
-    return (x1 - 3) ** 2 + (10 * (x2 + 2)) ** 2
+def ackley(x1, x2):
+    return (
+        -20 * math.exp(-0.2 * math.sqrt(0.5 * (x1 ** 2 + x2 ** 2)))
+        - math.exp(0.5 * (math.cos(2 * math.pi * x1) + math.cos(2 * math.pi * x2)))
+        + math.e
+        + 20
+    )
 
 
 def main():
-    cma_opts = {"mean": np.zeros(2), "sigma": 1.3}
-    optimizer = CMA(**cma_opts)
+    seed = 0
+    rng = np.random.RandomState(1)
+
+    bounds = np.array([[-32.768, 32.768], [-32.768, 32.768]])
+    lower_bounds, upper_bounds = bounds[:, 0], bounds[:, 1]
+
+    mean = lower_bounds + (rng.rand(2) * (upper_bounds - lower_bounds))
+    sigma = 32.768 * 2 / 5  # 1/5 of the domain width
+    optimizer = CMA(mean=mean, sigma=sigma, bounds=bounds, seed=0)
 
     # Multiplier for increasing population size before each restart.
     inc_popsize = 2
 
     print(" g    f(x1,x2)     x1      x2  ")
     print("===  ==========  ======  ======")
-    for generation in range(150):
+    for generation in range(200):
         solutions = []
         for _ in range(optimizer.population_size):
             x = optimizer.ask()
-            value = quadratic(x[0], x[1])
+            value = ackley(x[0], x[1])
             solutions.append((x, value))
 
             msg = "{g:3d}  {value:10.5f}  {x1:6.2f}  {x2:6.2f}".format(
@@ -29,8 +42,16 @@ def main():
         optimizer.tell(solutions)
 
         if optimizer.should_stop():
+            seed += 1
             popsize = optimizer.population_size * inc_popsize
-            optimizer = CMA(population_size=popsize, **cma_opts)
+            mean = lower_bounds + (rng.rand(2) * (upper_bounds - lower_bounds))
+            optimizer = CMA(
+                mean=mean,
+                sigma=sigma,
+                bounds=bounds,
+                seed=seed,
+                population_size=popsize,
+            )
             print("Restart CMA-ES with popsize={}".format(popsize))
 
 

--- a/examples/quadratic_function.py
+++ b/examples/quadratic_function.py
@@ -24,7 +24,7 @@ def main():
             print(msg)
         optimizer.tell(solutions)
 
-        if optimizer.should_terminate():
+        if optimizer.should_stop():
             break
 
 

--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -1,0 +1,29 @@
+import random
+
+import numpy as np
+from unittest import TestCase
+from cmaes import CMA
+
+
+class TestCMATerminate(TestCase):
+    def test_stop_if_objective_values_are_not_changed(self):
+        optimizer = CMA(mean=np.zeros(2), sigma=1.3)
+        popsize = optimizer.population_size
+        rng = np.random.RandomState(seed=1)
+
+        for i in range(optimizer._funhist_term):
+            optimizer.tell([(rng.randn(2), 0.01) for _ in range(popsize)])
+            self.assertFalse(optimizer.should_terminate())
+
+        optimizer.tell([(rng.randn(2), 0.01) for _ in range(popsize)])
+        self.assertTrue(optimizer.should_terminate())
+
+    def test_stop_if_detect_divergent_behavior(self):
+        optimizer = CMA(mean=np.zeros(2), sigma=1e-8)
+        popsize = optimizer.population_size
+        rng = random.Random(1)
+        nd_rng = np.random.RandomState(1)
+
+        solutions = [(nd_rng.randn(2), 1000 * rng.random()) for _ in range(popsize)]
+        optimizer.tell(solutions)
+        self.assertTrue(optimizer.should_terminate())

--- a/tests/test_termination_criterion.py
+++ b/tests/test_termination_criterion.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from cmaes import CMA
 
 
-class TestCMATerminate(TestCase):
+class TestTerminationCriterion(TestCase):
     def test_stop_if_objective_values_are_not_changed(self):
         optimizer = CMA(mean=np.zeros(2), sigma=1.3)
         popsize = optimizer.population_size
@@ -13,10 +13,10 @@ class TestCMATerminate(TestCase):
 
         for i in range(optimizer._funhist_term):
             optimizer.tell([(rng.randn(2), 0.01) for _ in range(popsize)])
-            self.assertFalse(optimizer.should_terminate())
+            self.assertFalse(optimizer.should_stop())
 
         optimizer.tell([(rng.randn(2), 0.01) for _ in range(popsize)])
-        self.assertTrue(optimizer.should_terminate())
+        self.assertTrue(optimizer.should_stop())
 
     def test_stop_if_detect_divergent_behavior(self):
         optimizer = CMA(mean=np.zeros(2), sigma=1e-8)
@@ -26,4 +26,4 @@ class TestCMATerminate(TestCase):
 
         solutions = [(nd_rng.randn(2), 1000 * rng.random()) for _ in range(popsize)]
         optimizer.tell(solutions)
-        self.assertTrue(optimizer.should_terminate())
+        self.assertTrue(optimizer.should_stop())

--- a/tests/test_termination_criterion.py
+++ b/tests/test_termination_criterion.py
@@ -1,6 +1,5 @@
-import random
-
 import numpy as np
+
 from unittest import TestCase
 from cmaes import CMA
 
@@ -11,19 +10,17 @@ class TestTerminationCriterion(TestCase):
         popsize = optimizer.population_size
         rng = np.random.RandomState(seed=1)
 
-        for i in range(optimizer._funhist_term):
-            optimizer.tell([(rng.randn(2), 0.01) for _ in range(popsize)])
+        for i in range(optimizer._funhist_term + 1):
             self.assertFalse(optimizer.should_stop())
+            optimizer.tell([(rng.randn(2), 0.01) for _ in range(popsize)])
 
-        optimizer.tell([(rng.randn(2), 0.01) for _ in range(popsize)])
         self.assertTrue(optimizer.should_stop())
 
     def test_stop_if_detect_divergent_behavior(self):
-        optimizer = CMA(mean=np.zeros(2), sigma=1e-8)
+        optimizer = CMA(mean=np.zeros(2), sigma=1e-4)
         popsize = optimizer.population_size
-        rng = random.Random(1)
         nd_rng = np.random.RandomState(1)
 
-        solutions = [(nd_rng.randn(2), 1000 * rng.random()) for _ in range(popsize)]
+        solutions = [(100 * nd_rng.randn(2), 0.01) for _ in range(popsize)]
         optimizer.tell(solutions)
         self.assertTrue(optimizer.should_stop())

--- a/visualizer/visualizer.py
+++ b/visualizer/visualizer.py
@@ -19,14 +19,12 @@ parser.add_argument(
     "--function", choices=["quadratic", "himmelblau", "rosenbrock", "six-hump-camel"],
 )
 parser.add_argument(
+    "--seed", type=int, default=0,
+)
+parser.add_argument(
     "--ipop", action="store_true",
 )
 args = parser.parse_args()
-
-optimizer = CMA(
-    mean=np.zeros(2), sigma=8 / 6, bounds=np.array([[-4, 4], [-4, 4]]), seed=1,
-)
-solutions = []
 
 rcParams["figure.figsize"] = 10, 5
 fig, (ax1, ax2) = plt.subplots(1, 2)
@@ -77,7 +75,7 @@ def six_hump_camel_contour(x1, x2):
 
 
 if args.function == "quadratic":
-    fig.suptitle("CMA Evolution Strategy for quadratic function")
+    title = "Quadratic function"
     objective = quadratic
     contour_function = quadratic_contour
     global_minimums = [
@@ -87,7 +85,7 @@ if args.function == "quadratic":
     x1_lower_bound, x1_upper_bound = -4, 4
     x2_lower_bound, x2_upper_bound = -4, 4
 elif args.function == "himmelblau":
-    fig.suptitle("CMA Evolution Strategy for Himmelblau function")
+    title = "Himmelblau function"
     objective = himmelbleu
     contour_function = himmelbleu_contour
     global_minimums = [
@@ -101,7 +99,7 @@ elif args.function == "himmelblau":
     x2_lower_bound, x2_upper_bound = -4, 4
 elif args.function == "rosenbrock":
     # https://www.sfu.ca/~ssurjano/rosen.html
-    fig.suptitle("CMA Evolution Strategy for Rosenbrock function")
+    title = "Rosenbrock function"
     objective = rosenbrock
     contour_function = rosenbrock_contour
     global_minimums = [
@@ -112,7 +110,7 @@ elif args.function == "rosenbrock":
     x2_lower_bound, x2_upper_bound = -5, 10
 elif args.function == "six-hump-camel":
     # https://www.sfu.ca/~ssurjano/camel6.html
-    fig.suptitle("CMA Evolution Strategy for Six-hump camel function")
+    title = "Six-hump camel function"
     objective = six_hump_camel
     contour_function = six_hump_camel_contour
     global_minimums = [
@@ -124,6 +122,13 @@ elif args.function == "six-hump-camel":
     x2_lower_bound, x2_upper_bound = -2, 2
 else:
     raise ValueError("invalid function type")
+
+
+bounds = np.array([[x1_lower_bound, x1_upper_bound], [x2_lower_bound, x2_upper_bound]])
+sigma = (x1_upper_bound - x2_lower_bound) / 5
+optimizer = CMA(mean=np.zeros(2), sigma=sigma, bounds=bounds, seed=args.seed)
+solutions = []
+rng = np.random.RandomState(args.seed)
 
 
 def init():
@@ -153,11 +158,13 @@ def update(frame):
 
         if args.ipop and optimizer.should_stop():
             popsize = optimizer.population_size * 2
+            lower_bounds, upper_bounds = bounds[:, 0], bounds[:, 1]
+            mean = lower_bounds + (rng.rand(2) * (upper_bounds - lower_bounds))
             optimizer = CMA(
-                mean=np.zeros(2),
-                sigma=8 / 6,
-                bounds=np.array([[-4, 4], [-4, 4]]),
-                seed=1,
+                mean=mean,
+                sigma=sigma,
+                bounds=bounds,
+                seed=args.seed,
                 population_size=popsize,
             )
             print(f"Restart CMA-ES with popsize={popsize} at i={frame}")
@@ -171,18 +178,22 @@ def update(frame):
     )
     solutions.append(solution)
 
+    # Update title
+    fig.suptitle(f"{title} trial={frame}")
+
     # Plot sample points
     ax1.plot(x[0], x[1], "o", c="r", label="2d", alpha=0.5)
 
     # Plot multivariate gaussian distribution of CMA-ES
-    mu = optimizer._mean
-    sigma = optimizer._C
     x, y = np.mgrid[
         x1_lower_bound:x1_upper_bound:0.01, x2_lower_bound:x2_upper_bound:0.01
     ]
-    rv = stats.multivariate_normal(mu, sigma)
+    rv = stats.multivariate_normal(optimizer._mean, optimizer._C)
     pos = np.dstack((x, y))
     ax2.contourf(x, y, rv.pdf(pos))
+
+    if frame % 50 == 0:
+        print(f"Processing frame {frame}")
 
 
 def main():


### PR DESCRIPTION
## Summary

Added `.should_stop()` method that returns `True` when CMA-ES converges to local minimum.
You can easily implement IPOP-CMA-ES and BIPOP-CMA-ES by using this method.

[Auger, A., Hansen, N.: A restart CMA evolution strategy with increasing population size. In: Proceedings of the 2005 IEEE Congress on Evolutionary Computation (CEC’2005), pp. 1769–1776 (2005a)](https://sci2s.ugr.es/sites/default/files/files/TematicWebSites/EAMHCO/contributionsCEC05/auger05ARCMA.pdf)

## Usage

```python
import math
import numpy as np
from cmaes import CMA


def ackley(x1, x2):
    # https://www.sfu.ca/~ssurjano/ackley.html
    return (
        -20 * math.exp(-0.2 * math.sqrt(0.5 * (x1 ** 2 + x2 ** 2)))
        - math.exp(0.5 * (math.cos(2 * math.pi * x1) + math.cos(2 * math.pi * x2)))
        + math.e + 20
    )


if __name__ == "__main__":
    bounds = np.array([[-32.768, 32.768], [-32.768, 32.768]])
    sigma = (np.max(bounds) - np.min(bounds)) / 5  # 1/5 of the domain width
    optimizer = CMA(mean=np.random.rand(2), sigma=sigma)

    for generation in range(200):
        solutions = []
        for _ in range(optimizer.population_size):
            x = optimizer.ask()
            value = ackley(x[0], x[1])
            solutions.append((x, value))
            print(f"#{generation} {value} (x1={x[0]}, x2 = {x[1]})")
        optimizer.tell(solutions)

        if optimizer.should_stop():
            # popsize multiplied by 2 (or 3) before each restart.
            popsize = optimizer.population_size * 2
            optimizer = CMA(mean=np.random.rand(2), sigma=sigma, population_size=popsize)
            print(f"Restart CMA-ES with popsize={popsize}")

```

## Visualizer

![himmelblau](https://user-images.githubusercontent.com/5564044/88465209-1e151500-cefc-11ea-824d-57f70000638b.gif)

## TODO

* [x] Update README
* [x] Add example
* [x] Add tests
* [x] Update visualizer
