### PR TITLE
Revert development status

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 license = MIT License
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 4 - Beta
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python


### PR DESCRIPTION
I bumped development status to `Production Stable` from `Beta` at #43.
Note that #43 is merged after released v0.5.1. So still not published.
https://pypi.org/project/cmaes/0.5.1/

I revert it due to #49 and #50.