### PR TITLE
Add an example of BIPOP-CMA-ES

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,4 +27,5 @@ jobs:
           pip install --progress-bar off -U .
       - run: python examples/quadratic_function.py
       - run: python examples/ipop_cmaes.py
+      - run: python examples/bipop_cmaes.py
       - run: python examples/optuna_sampler.py

--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-ES) [1] impleme
 </details>
 
 <details>
-<summary>Himmelblau function with IPOP-CMA-ES.</summary>
+<summary>IPOP-CMA-ES on Himmelblau function.</summary>
 
-![visualize-ipop-cmaes-himmelblau](https://user-images.githubusercontent.com/5564044/88465209-1e151500-cefc-11ea-824d-57f70000638b.gif)
+![visualize-ipop-cmaes-himmelblau](https://user-images.githubusercontent.com/5564044/88472274-f9e12480-cf4b-11ea-8aff-2a859eb51a15.gif)
+
+</details>
+
+<details>
+<summary>BIPOP-CMA-ES on Himmelblau function.</summary>
+
+![visualize-bipop-cmaes-himmelblau](https://user-images.githubusercontent.com/5564044/88471815-55111800-cf48-11ea-8933-5a4b48c49eba.gif)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     lower_bounds, upper_bounds = bounds[:, 0], bounds[:, 1]
 
     mean = lower_bounds + (np.random.rand(2) * (upper_bounds - lower_bounds))
-    sigma = (np.max(bounds) - np.min(bounds)) / 5  # 1/5 of the domain width
+    sigma = 32.768 * 2 / 5  # 1/5 of the domain width
     optimizer = CMA(mean=mean, sigma=sigma, bounds=bounds, seed=0)
 
     for generation in range(200):
@@ -123,6 +123,84 @@ if __name__ == "__main__":
 ```
 
 </details>
+
+<details>
+<summary>Example of BIPOP-CMA-ES [4]</summary>
+
+Here is an example of BIPOP-CMA-ES which applies two interlaced restart strategies,
+one with an increasing population size and one with varying small population sizes.
+
+```python
+import math
+import numpy as np
+from cmaes import CMA
+
+def ackley(x1, x2):
+    # https://www.sfu.ca/~ssurjano/ackley.html
+    return (
+        -20 * math.exp(-0.2 * math.sqrt(0.5 * (x1 ** 2 + x2 ** 2)))
+        - math.exp(0.5 * (math.cos(2 * math.pi * x1) + math.cos(2 * math.pi * x2)))
+        + math.e + 20
+    )
+
+if __name__ == "__main__":
+    bounds = np.array([[-32.768, 32.768], [-32.768, 32.768]])
+    lower_bounds, upper_bounds = bounds[:, 0], bounds[:, 1]
+
+    mean = lower_bounds + (np.random.rand(2) * (upper_bounds - lower_bounds))
+    sigma = 32.768 * 2 / 5  # 1/5 of the domain width
+    optimizer = CMA(mean=mean, sigma=sigma, bounds=bounds, seed=0)
+
+    n_restarts = 0  # A small restart doesn't count in the n_restarts
+    small_n_eval, large_n_eval = 0, 0
+    popsize0 = optimizer.population_size
+    inc_popsize = 2
+
+    # Initial run is with "normal" population size; it is
+    # the large population before first doubling, but its
+    # budget accounting is the same as in case of small
+    # population.
+    poptype = "small"
+
+    for generation in range(200):
+        solutions = []
+        for _ in range(optimizer.population_size):
+            x = optimizer.ask()
+            value = ackley(x[0], x[1])
+            solutions.append((x, value))
+            print(f"#{generation} {value} (x1={x[0]}, x2 = {x[1]})")
+        optimizer.tell(solutions)
+
+        if optimizer.should_stop():
+            n_eval = optimizer.population_size * optimizer.generation
+            if poptype == "small":
+                small_n_eval += n_eval
+            else:  # poptype == "large"
+                large_n_eval += n_eval
+
+            if small_n_eval < large_n_eval:
+                poptype = "small"
+                popsize_multiplier = inc_popsize ** n_restarts
+                popsize = math.floor(
+                    popsize0 * popsize_multiplier ** (np.random.uniform() ** 2)
+                )
+            else:
+                poptype = "large"
+                n_restarts += 1
+                popsize = popsize0 * (inc_popsize ** n_restarts)
+
+            mean = lower_bounds + (np.random.rand(2) * (upper_bounds - lower_bounds))
+            optimizer = CMA(
+                mean=mean,
+                sigma=sigma,
+                bounds=bounds,
+                population_size=popsize,
+            )
+            print("Restart CMA-ES with popsize={} ({})".format(popsize, poptype))
+```
+
+</details>
+
 
 ## Benchmark results
 
@@ -148,3 +226,4 @@ I respect all libraries involved in CMA-ES.
 * [1] [N. Hansen, The CMA Evolution Strategy: A Tutorial. arXiv:1604.00772, 2016.](https://arxiv.org/abs/1604.00772)
 * [2] [Takuya Akiba, Shotaro Sano, Toshihiko Yanase, Takeru Ohta, Masanori Koyama. 2019. Optuna: A Next-generation Hyperparameter Optimization Framework. In The 25th ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD ’19), August 4–8, 2019.](https://dl.acm.org/citation.cfm?id=3330701)
 * [3] [Auger, A., Hansen, N.: A restart CMA evolution strategy with increasing population size. In: Proceedings of the 2005 IEEE Congress on Evolutionary Computation (CEC’2005), pp. 1769–1776 (2005a)](https://sci2s.ugr.es/sites/default/files/files/TematicWebSites/EAMHCO/contributionsCEC05/auger05ARCMA.pdf)
+* [4] [Hansen N. Benchmarking a BI-Population CMA-ES on the BBOB-2009 Function Testbed. In the workshop Proceedings of the Genetic and Evolutionary Computation Conference, GECCO, pages 2389–2395. ACM, 2009.](https://hal.inria.fr/inria-00382093/document)

--- a/examples/bipop_cmaes.py
+++ b/examples/bipop_cmaes.py
@@ -1,0 +1,76 @@
+import math
+import numpy as np
+from cmaes import CMA
+
+
+def ackley(x1, x2):
+    return (
+        -20 * math.exp(-0.2 * math.sqrt(0.5 * (x1 ** 2 + x2 ** 2)))
+        - math.exp(0.5 * (math.cos(2 * math.pi * x1) + math.cos(2 * math.pi * x2)))
+        + math.e
+        + 20
+    )
+
+
+def main():
+    seed = 0
+    rng = np.random.RandomState(0)
+
+    bounds = np.array([[-32.768, 32.768], [-32.768, 32.768]])
+    lower_bounds, upper_bounds = bounds[:, 0], bounds[:, 1]
+
+    mean = lower_bounds + (rng.rand(2) * (upper_bounds - lower_bounds))
+    sigma = 32.768 * 2 / 5  # 1/5 of the domain width
+    optimizer = CMA(mean=mean, sigma=sigma, bounds=bounds, seed=0)
+
+    n_restarts = 0  # A small restart doesn't count in the n_restarts
+    small_n_eval, large_n_eval = 0, 0
+    popsize0 = optimizer.population_size
+    inc_popsize = 2
+
+    # Initial run is with "normal" population size; it is
+    # the large population before first doubling, but its
+    # budget accounting is the same as in case of small
+    # population.
+    poptype = "small"
+
+    while n_restarts <= 5:
+        solutions = []
+        for _ in range(optimizer.population_size):
+            x = optimizer.ask()
+            value = ackley(x[0], x[1])
+            solutions.append((x, value))
+            # print("{:10.5f}  {:6.2f}  {:6.2f}".format(value, x[0], x[1]))
+        optimizer.tell(solutions)
+
+        if optimizer.should_stop():
+            seed += 1
+            n_eval = optimizer.population_size * optimizer.generation
+            if poptype == "small":
+                small_n_eval += n_eval
+            else:  # poptype == "large"
+                large_n_eval += n_eval
+
+            if small_n_eval < large_n_eval:
+                poptype = "small"
+                popsize_multiplier = inc_popsize ** n_restarts
+                popsize = math.floor(
+                    popsize0 * popsize_multiplier ** (rng.uniform() ** 2)
+                )
+            else:
+                poptype = "large"
+                n_restarts += 1
+                popsize = popsize0 * (inc_popsize ** n_restarts)
+            mean = lower_bounds + (rng.rand(2) * (upper_bounds - lower_bounds))
+            optimizer = CMA(
+                mean=mean,
+                sigma=sigma,
+                bounds=bounds,
+                seed=seed,
+                population_size=popsize,
+            )
+            print("Restart CMA-ES with popsize={} ({})".format(popsize, poptype))
+
+
+if __name__ == "__main__":
+    main()

--- a/visualizer/visualizer.py
+++ b/visualizer/visualizer.py
@@ -1,9 +1,23 @@
 """
 Usage:
+  visualizer.py [-h] [--function {quadratic,himmelblau,rosenbrock,six-hump-camel}] [--seed SEED] [--frames FRAMES] [--interval INTERVAL] [--pop-per-frame POP_PER_FRAME] [--restart-strategy {ipop,bipop}]
 
-  python3 visualizer/visualizer.py --function six-hump-camel
+Optional arguments:
+  -h, --help            show this help message and exit
+  --function {quadratic,himmelblau,rosenbrock,six-hump-camel}
+  --seed SEED
+  --frames FRAMES
+  --interval INTERVAL
+  --pop-per-frame POP_PER_FRAME
+  --restart-strategy {ipop,bipop}
+
+Example:
+  python3 visualizer.py --function six-hump-camel --pop-per-frame 2
+  python visualizer/visualizer.py --function himmelblau --restart-strategy ipop --frames 500 --interval 10 --pop-per-frame 6
 """
 import argparse
+import math
+
 import numpy as np
 from scipy import stats
 
@@ -19,10 +33,19 @@ parser.add_argument(
     "--function", choices=["quadratic", "himmelblau", "rosenbrock", "six-hump-camel"],
 )
 parser.add_argument(
-    "--seed", type=int, default=0,
+    "--seed", type=int, default=1,
 )
 parser.add_argument(
-    "--ipop", action="store_true",
+    "--frames", type=int, default=100,
+)
+parser.add_argument(
+    "--interval", type=int, default=20,
+)
+parser.add_argument(
+    "--pop-per-frame", type=int, default=1,
+)
+parser.add_argument(
+    "--restart-strategy", choices=["ipop", "bipop"], default="",
 )
 args = parser.parse_args()
 
@@ -74,8 +97,9 @@ def six_hump_camel_contour(x1, x2):
     return np.log(six_hump_camel(x1, x2) + 1.0316)
 
 
+function_name = ""
 if args.function == "quadratic":
-    title = "Quadratic function"
+    function_name = "Quadratic function"
     objective = quadratic
     contour_function = quadratic_contour
     global_minimums = [
@@ -85,7 +109,7 @@ if args.function == "quadratic":
     x1_lower_bound, x1_upper_bound = -4, 4
     x2_lower_bound, x2_upper_bound = -4, 4
 elif args.function == "himmelblau":
-    title = "Himmelblau function"
+    function_name = "Himmelblau function"
     objective = himmelbleu
     contour_function = himmelbleu_contour
     global_minimums = [
@@ -99,7 +123,7 @@ elif args.function == "himmelblau":
     x2_lower_bound, x2_upper_bound = -4, 4
 elif args.function == "rosenbrock":
     # https://www.sfu.ca/~ssurjano/rosen.html
-    title = "Rosenbrock function"
+    function_name = "Rosenbrock function"
     objective = rosenbrock
     contour_function = rosenbrock_contour
     global_minimums = [
@@ -110,7 +134,7 @@ elif args.function == "rosenbrock":
     x2_lower_bound, x2_upper_bound = -5, 10
 elif args.function == "six-hump-camel":
     # https://www.sfu.ca/~ssurjano/camel6.html
-    title = "Six-hump camel function"
+    function_name = "Six-hump camel function"
     objective = six_hump_camel
     contour_function = six_hump_camel_contour
     global_minimums = [
@@ -124,11 +148,20 @@ else:
     raise ValueError("invalid function type")
 
 
+seed = args.seed
 bounds = np.array([[x1_lower_bound, x1_upper_bound], [x2_lower_bound, x2_upper_bound]])
 sigma = (x1_upper_bound - x2_lower_bound) / 5
-optimizer = CMA(mean=np.zeros(2), sigma=sigma, bounds=bounds, seed=args.seed)
+optimizer = CMA(mean=np.zeros(2), sigma=sigma, bounds=bounds, seed=seed)
 solutions = []
-rng = np.random.RandomState(args.seed)
+trial_number = 0
+rng = np.random.RandomState(seed)
+
+# Variables for IPOP and BIPOP
+inc_popsize = 2
+n_restarts = 0  # A small restart doesn't count in the n_restarts
+small_n_eval, large_n_eval = 0, 0
+popsize0 = optimizer.population_size
+poptype = "small"
 
 
 def init():
@@ -150,39 +183,81 @@ def init():
     ax1.contour(x1, x2, contour_function(x1, x2), 30, cmap=bw)
 
 
+def get_next_popsize():
+    global optimizer, n_restarts, poptype, small_n_eval, large_n_eval
+    if args.restart_strategy == "ipop":
+        n_restarts += 1
+        popsize = optimizer.population_size * inc_popsize
+        print(f"Restart CMA-ES with popsize={popsize} at trial={trial_number}")
+        return popsize
+    elif args.restart_strategy == "bipop":
+        n_eval = optimizer.population_size * optimizer.generation
+        if poptype == "small":
+            small_n_eval += n_eval
+        else:  # poptype == "large"
+            large_n_eval += n_eval
+
+        if small_n_eval < large_n_eval:
+            poptype = "small"
+            popsize_multiplier = inc_popsize ** n_restarts
+            popsize = math.floor(popsize0 * popsize_multiplier ** (rng.uniform() ** 2))
+        else:
+            poptype = "large"
+            n_restarts += 1
+            popsize = popsize0 * (inc_popsize ** n_restarts)
+        print(
+            f"Restart CMA-ES with popsize={popsize} ({poptype}) at trial={trial_number}"
+        )
+        return
+    raise Exception("must not reach here")
+
+
 def update(frame):
-    global solutions, optimizer
+    global solutions, optimizer, trial_number
     if len(solutions) == optimizer.population_size:
         optimizer.tell(solutions)
         solutions = []
 
-        if args.ipop and optimizer.should_stop():
-            popsize = optimizer.population_size * 2
+        if optimizer.should_stop():
+            popsize = get_next_popsize()
             lower_bounds, upper_bounds = bounds[:, 0], bounds[:, 1]
             mean = lower_bounds + (rng.rand(2) * (upper_bounds - lower_bounds))
             optimizer = CMA(
                 mean=mean,
                 sigma=sigma,
                 bounds=bounds,
-                seed=args.seed,
+                seed=seed,
                 population_size=popsize,
             )
-            print(f"Restart CMA-ES with popsize={popsize} at i={frame}")
 
-    x = optimizer.ask()
-    evaluation = objective(x[0], x[1])
+    n_sample = min(optimizer.population_size - len(solutions), args.pop_per_frame)
+    for i in range(n_sample):
+        x = optimizer.ask()
+        evaluation = objective(x[0], x[1])
 
-    solution = (
-        x,
-        evaluation,
-    )
-    solutions.append(solution)
+        # Plot sample points
+        ax1.plot(x[0], x[1], "o", c="r", label="2d", alpha=0.5)
+
+        solution = (
+            x,
+            evaluation,
+        )
+        solutions.append(solution)
+    trial_number += n_sample
 
     # Update title
-    fig.suptitle(f"{title} trial={frame}")
-
-    # Plot sample points
-    ax1.plot(x[0], x[1], "o", c="r", label="2d", alpha=0.5)
+    if args.restart_strategy == "ipop":
+        fig.suptitle(
+            f"IPOP-CMA-ES {function_name} trial={trial_number} "
+            f"popsize={optimizer.population_size}"
+        )
+    elif args.restart_strategy == "bipop":
+        fig.suptitle(
+            f"BIPOP-CMA-ES {function_name} trial={trial_number} "
+            f"popsize={optimizer.population_size} ({poptype})"
+        )
+    else:
+        fig.suptitle(f"CMA-ES {function_name} trial={trial_number}")
 
     # Plot multivariate gaussian distribution of CMA-ES
     x, y = np.mgrid[
@@ -197,9 +272,13 @@ def update(frame):
 
 
 def main():
-    frames = 1000 if args.ipop else 150
     ani = animation.FuncAnimation(
-        fig, update, frames=frames, init_func=init, blit=False, interval=50
+        fig,
+        update,
+        frames=args.frames,
+        init_func=init,
+        blit=False,
+        interval=args.interval,
     )
     ani.save(f"./tmp/{args.function}.mp4")
 

--- a/visualizer/visualizer.py
+++ b/visualizer/visualizer.py
@@ -1,6 +1,6 @@
 """
 Usage:
-  visualizer.py [-h] [--function {quadratic,himmelblau,rosenbrock,six-hump-camel}] [--seed SEED] [--frames FRAMES] [--interval INTERVAL] [--pop-per-frame POP_PER_FRAME] [--restart-strategy {ipop,bipop}]
+  visualizer.py OPTIONS
 
 Optional arguments:
   -h, --help            show this help message and exit
@@ -13,7 +13,9 @@ Optional arguments:
 
 Example:
   python3 visualizer.py --function six-hump-camel --pop-per-frame 2
-  python visualizer/visualizer.py --function himmelblau --restart-strategy ipop --frames 500 --interval 10 --pop-per-frame 6
+
+  python3 visualizer/visualizer.py --function himmelblau \
+    --restart-strategy ipop --frames 500 --interval 10 --pop-per-frame 6
 """
 import argparse
 import math


### PR DESCRIPTION
## Summary

BIPOP-CMA-ES is a multi-start CMA-ES with equal budgets for two interlaced restart strategies, one with an increasing population size and one with varying small population sizes. We've already implemented termination criteria for I-POP-CMA-ES at #50. So in this pull request, I add an example of BI-POP-CMA-ES and the visualizer support.

[Hansen N. Benchmarking a BI-Population CMA-ES on the BBOB-2009 Function Testbed. In the workshop Proceedings of the Genetic and Evolutionary Computation Conference, GECCO, pages 2389–2395. ACM, 2009.](https://hal.inria.fr/inria-00382093/document)

## Visualizer

![bipop-himmelblau](https://user-images.githubusercontent.com/5564044/88471815-55111800-cf48-11ea-8933-5a4b48c49eba.gif)

## Example

```
$ python examples/bipop_cmaes.py 
Restart CMA-ES with popsize=12 (large)
Restart CMA-ES with popsize=11 (small)
Restart CMA-ES with popsize=24 (large)
Restart CMA-ES with popsize=21 (small)
Restart CMA-ES with popsize=48 (large)
Restart CMA-ES with popsize=9 (small)
Restart CMA-ES with popsize=96 (large)
Restart CMA-ES with popsize=18 (small)
Restart CMA-ES with popsize=6 (small)
Restart CMA-ES with popsize=11 (small)
Restart CMA-ES with popsize=192 (large)
Restart CMA-ES with popsize=30 (small)
Restart CMA-ES with popsize=16 (small)
Restart CMA-ES with popsize=77 (small)
Restart CMA-ES with popsize=84 (small)
Restart CMA-ES with popsize=6 (small)
Restart CMA-ES with popsize=384 (large)
```

## TODOs

* [x] Example
* [x] README
* [x] Visualizer