### PR TITLE
Run examples with only stable optuna version

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,17 +13,17 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
-        optuna-version: ['optuna==1.3', 'git+https://github.com/optuna/optuna.git']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies with Optuna ${{ matrix.optuna-version }}
+          architecture: x64
+      - name: Install dependencies
         run: |
           pip install -U pip setuptools
-          pip install --progress-bar off ${{ matrix.optuna-version }}
+          pip install --progress-bar off optuna
           pip install --progress-bar off -U .
       - run: python examples/quadratic_function.py
       - run: python examples/optuna_sampler.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,10 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.x'
+          architecture: x64
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
@@ -22,10 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.x'
+          architecture: x64
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools


### PR DESCRIPTION
This library has already removed Optuna samplers. So no longer we don't need to test various optuna version.