### PR TITLE
Fix coordinate rotation

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -28,4 +28,5 @@ jobs:
       - run: python examples/quadratic_function.py
       - run: python examples/ipop_cmaes.py
       - run: python examples/bipop_cmaes.py
+      - run: python examples/ellipsoid_function.py
       - run: python examples/optuna_sampler.py

--- a/cmaes/_cma.py
+++ b/cmaes/_cma.py
@@ -296,7 +296,7 @@ class CMA:
         self._mean += self._cm * self._sigma * y_w
 
         # Step-size control
-        C_2 = B.dot(np.diag(1 / D)).dot(B)  # C^(-1/2) = B D^(-1) B^T
+        C_2 = B.dot(np.diag(1 / D)).dot(B.T)  # C^(-1/2) = B D^(-1) B^T
         self._p_sigma = (1 - self._c_sigma) * self._p_sigma + math.sqrt(
             self._c_sigma * (2 - self._c_sigma) * self._mu_eff
         ) * C_2.dot(y_w)

--- a/examples/ellipsoid_function.py
+++ b/examples/ellipsoid_function.py
@@ -1,0 +1,37 @@
+import numpy as np
+from cmaes import CMA
+
+
+def ellipsoid(x):
+    n = len(x)
+    if len(x) < 2:
+        raise ValueError("dimension must be greater one")
+    return sum([(1000 ** (i / (n - 1)) * x[i]) ** 2 for i in range(n)])
+
+
+def main():
+    dim = 40
+    optimizer = CMA(mean=3 * np.ones(dim), sigma=2.0)
+    print(" evals    f(x)")
+    print("======  ==========")
+
+    evals = 0
+    while True:
+        solutions = []
+        for _ in range(optimizer.population_size):
+            x = optimizer.ask()
+            value = ellipsoid(x)
+            evals +=1
+            solutions.append((x, value))
+            if evals % 3000 == 0:
+                print(
+                    f"{evals:5d}  {value:10.5f}"
+                )
+        optimizer.tell(solutions)
+
+        if optimizer.should_stop():
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ellipsoid_function.py
+++ b/examples/ellipsoid_function.py
@@ -21,12 +21,10 @@ def main():
         for _ in range(optimizer.population_size):
             x = optimizer.ask()
             value = ellipsoid(x)
-            evals +=1
+            evals += 1
             solutions.append((x, value))
             if evals % 3000 == 0:
-                print(
-                    f"{evals:5d}  {value:10.5f}"
-                )
+                print(f"{evals:5d}  {value:10.5f}")
         optimizer.tell(solutions)
 
         if optimizer.should_stop():


### PR DESCRIPTION
This PR fix the coordinate of the covariance matrix.
To clarify the effect of the above fix, I've added a case where the current implementation fails.

## Before
The CMA diverges due to the lack of specification of the coordinate system.

```
 evals    f(x)
======  ==========
 3000  1738123.37543
 6000  19991928.23666
 9000  7081738487880.13770
```

## After
With this modification, the CMA will converge properly.

```
  evals    f(x)
======  ==========
 3000  208462.46183
 6000  37443.67228
 9000  12165.74144
12000  5975.17002
15000  3067.84338
18000  1614.96333
21000   832.31420
24000   349.38618
27000   180.07809
30000    85.79394
33000    28.02802
36000     9.34316
39000     1.80444
42000     0.10396
45000     0.01673
48000     0.00037
51000     0.00000
```

Note:
This phenomenon does not appear in problems that do not need to consider the scale of variables such as Sphere function.
