### PR TITLE
Fix mypy error at numpy v1.20.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ setup_requires =
     setuptools>=46.4.0
     wheel
 install_requires =
-    numpy
+    numpy<1.20.0
 
 [options.extras_require]
 benchmark =


### PR DESCRIPTION
Update install_requires instead of error fix because Numpy v1.20.0 drops the support of Python 3.6.