### PR TITLE
Running benchmark of Warm Starting CMA-ES on GitHub Actions.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -229,12 +229,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./toxic-lightgbm-warm-start.zip
-          key: toxic-lightgbm-warm-start
+          key: toxic-lightgbm-warm-start-zip
       - name: Download toxic-dataset
         if: steps.cache-toxic-surrogate.outputs.cache-hit != 'true'
-        run: |
-          curl -L https://storage.googleapis.com/hpo-bench/kurobako-surrogate/toxic-lightgbm-warm-start.zip -o toxic-lightgbm-warm-start.zip
-          unzip ./toxic-lightgbm-warm-start.zip
+        run: curl -L https://storage.googleapis.com/hpo-bench/kurobako-surrogate/toxic-lightgbm-warm-start.zip -o toxic-lightgbm-warm-start.zip
+      - name: Unarchive toxic-dataset
+        run: unzip ./toxic-lightgbm-warm-start.zip
 
       - name: Run kurobako for Warm Starting CMA-ES
         env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,7 +45,6 @@ jobs:
         id: kurobako-plot
         with:
           report-json-path: './kurobako-report.json'
-          error-bar: 'true'
       - name: Generate kurobako markdown report
         run: cat ./kurobako-report.json | ./kurobako report > ./kurobako-report.md
 
@@ -249,6 +248,7 @@ jobs:
         id: kurobako-plot
         with:
           report-json-path: './kurobako-report.json'
+          error-bar: 'true'
       - name: Generate kurobako markdown report
         run: cat ./kurobako-report.json | ./kurobako report > ./kurobako-report.md
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,11 +28,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./kurobako
-          key: kurobako-0-2-8
+          key: kurobako-0-2-9
       - name: Download kurobako CLI
         if: steps.cache-kurobako.outputs.cache-hit != 'true'
         run: |
-          curl -L https://github.com/sile/kurobako/releases/download/0.2.8/kurobako-0.2.8.linux-amd64 -o kurobako
+          curl -L https://github.com/sile/kurobako/releases/download/0.2.9/kurobako-0.2.9.linux-amd64 -o kurobako
           chmod +x kurobako
           ./kurobako -h
 
@@ -120,11 +120,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./kurobako
-          key: kurobako-0-2-8
+          key: kurobako-0-2-9
       - name: Download kurobako CLI
         if: steps.cache-kurobako.outputs.cache-hit != 'true'
         run: |
-          curl -L https://github.com/sile/kurobako/releases/download/0.2.8/kurobako-0.2.8.linux-amd64 -o kurobako
+          curl -L https://github.com/sile/kurobako/releases/download/0.2.9/kurobako-0.2.9.linux-amd64 -o kurobako
           chmod +x kurobako
           ./kurobako -h
 
@@ -194,3 +194,111 @@ jobs:
         with:
           name: kurobako-report
           path: kurobako-report-rastrigin.md
+
+  benchmark-toxic-warm-start:
+    name: Run kurobako benchmark
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+      - run: pip install -U pip setuptools
+      - run: python setup.py develop
+      - run: pip install --progress-bar off -r requirements-bench.txt
+      - run: pip install --progress-bar off -U git+https://github.com/sile/kurobako-py
+      - run: pip install --progress-bar off -U git+https://github.com/optuna/optuna.git
+      - name: Cache kurobako CLI
+        id: cache-kurobako
+        uses: actions/cache@v2
+        with:
+          path: ./kurobako
+          key: kurobako-0-2-9
+      - name: Download kurobako CLI
+        if: steps.cache-kurobako.outputs.cache-hit != 'true'
+        run: |
+          curl -L https://github.com/sile/kurobako/releases/download/0.2.9/kurobako-0.2.9.linux-amd64 -o kurobako
+          chmod +x kurobako
+          ./kurobako -h
+
+      - name: Cache surrogate model of tuning lightgbm for Toxic Data Challenge
+        id: cache-toxic-surrogate
+        uses: actions/cache@v2
+        with:
+          path: ./toxic-lightgbm-warm-start.zip
+          key: toxic-lightgbm-warm-start
+      - name: Download toxic-dataset
+        if: steps.cache-toxic-surrogate.outputs.cache-hit != 'true'
+        run: |
+          curl -L https://storage.googleapis.com/hpo-bench/kurobako-surrogate/toxic-lightgbm-warm-start.zip -o toxic-lightgbm-warm-start.zip
+          unzip ./toxic-lightgbm-warm-start.zip
+
+      - name: Run kurobako for Warm Starting CMA-ES
+        env:
+          KUROBAKO: ./kurobako
+          SURROGATE_ROOT: ./toxic-lightgbm-warm-start
+          WARM_START: 100
+          REPEATS: 12
+          BUDGET: 30
+        run: ./benchmark/runner.sh toxic-lightgbm ./kurobako-report.json
+      - name: Plot kurobako result
+        uses: c-bata/github-actions-kurobako/plot@v1
+        id: kurobako-plot
+        with:
+          report-json-path: './kurobako-report.json'
+      - name: Generate kurobako markdown report
+        run: cat ./kurobako-report.json | ./kurobako report > ./kurobako-report.md
+
+      - name: Set HAS_SECRET flag
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          if [ ! -z $GCP_PROJECT_ID ] && [ ! -z $GCP_SA_KEY ]; then
+              echo "HAS_SECRET=1" >> $GITHUB_ENV
+          else
+              echo "HAS_SECRET=0" >> $GITHUB_ENV
+          fi
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        if: ${{ env.HAS_SECRET == 1 }}
+        with:
+          version: '275.0.0'
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - run: gcloud info
+        if: ${{ env.HAS_SECRET == 1 }}
+      - run: gcloud config set project ${{ secrets.GCP_PROJECT_ID }}
+        if: ${{ env.HAS_SECRET == 1 }}
+      - run: gsutil cp ${{ steps.kurobako-plot.outputs.image-path }} gs://kurobako-reports/${{ github.repository }}/toxic-lightgbm-${{ github.sha }}.png
+        if: ${{ env.HAS_SECRET == 1 }}
+      - name: Comment to a pull request
+        if: ${{ env.HAS_SECRET == 1 }}
+        uses: c-bata/github-actions-kurobako@v2
+        with:
+          report-md-path: './kurobako-report.md'
+          public-image-url: https://storage.googleapis.com/kurobako-reports/${{ github.repository }}/toxic-lightgbm-${{ github.sha }}.png
+          title: 'Tuning LightGBM for Kaggle Toxic Data Challenge (Surrogate ver.)'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: mv ./kurobako-report.json ./kurobako-report-toxic-lightgbm.json
+      - uses: actions/upload-artifact@v2
+        with:
+          name: kurobako-report
+          path: kurobako-report-toxic-lightgbm.json
+
+      - run: mv ${{ steps.kurobako-plot.outputs.image-path }} toxic-lightgbm.png
+        if: ${{ env.HAS_SECRET == 0 }}
+      - run: mv ./kurobako-report.md ./kurobako-report-toxic-lightgbm.md
+        if: ${{ env.HAS_SECRET == 0 }}
+      - uses: actions/upload-artifact@v2
+        if: ${{ env.HAS_SECRET == 0 }}
+        with:
+          name: kurobako-report
+          path: toxic-lightgbm.png
+      - uses: actions/upload-artifact@v2
+        if: ${{ env.HAS_SECRET == 0 }}
+        with:
+          name: kurobako-report
+          path: kurobako-report-toxic-lightgbm.md

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,10 +41,11 @@ jobs:
           KUROBAKO: ./kurobako
         run: ./benchmark/runner.sh six-hump-camel ./kurobako-report.json
       - name: Plot kurobako result
-        uses: c-bata/github-actions-kurobako/plot@v1
+        uses: c-bata/github-actions-kurobako/plot@v3
         id: kurobako-plot
         with:
           report-json-path: './kurobako-report.json'
+          error-bar: 'true'
       - name: Generate kurobako markdown report
         run: cat ./kurobako-report.json | ./kurobako report > ./kurobako-report.md
 
@@ -136,7 +137,7 @@ jobs:
           BUDGET: 2500
         run: ./benchmark/runner.sh rastrigin ./kurobako-report.json
       - name: Plot kurobako result
-        uses: c-bata/github-actions-kurobako/plot@v1
+        uses: c-bata/github-actions-kurobako/plot@v3
         id: kurobako-plot
         with:
           report-json-path: './kurobako-report.json'
@@ -244,7 +245,7 @@ jobs:
           BUDGET: 30
         run: ./benchmark/runner.sh toxic-lightgbm ./kurobako-report.json
       - name: Plot kurobako result
-        uses: c-bata/github-actions-kurobako/plot@v1
+        uses: c-bata/github-actions-kurobako/plot@v3
         id: kurobako-plot
         with:
           report-json-path: './kurobako-report.json'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -279,7 +279,7 @@ jobs:
         with:
           report-md-path: './kurobako-report.md'
           public-image-url: https://storage.googleapis.com/kurobako-reports/${{ github.repository }}/toxic-lightgbm-${{ github.sha }}.png
-          title: 'Tuning LightGBM for Kaggle Toxic Data Challenge (Surrogate ver.)'
+          title: 'Tuning LightGBM for Kaggle Toxic Challenge (Surrogate)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/benchmark/optuna_solver.py
+++ b/benchmark/optuna_solver.py
@@ -2,12 +2,13 @@ import argparse
 import optuna
 import warnings
 
-from cmaes import SepCMA
 from kurobako import solver
 from kurobako.solver.optuna import OptunaSolverFactory
 
 warnings.filterwarnings(
-    "default", category=optuna.exceptions.ExperimentalWarning, module="optuna.samplers"
+    "ignore",
+    category=optuna.exceptions.ExperimentalWarning,
+    module="optuna.samplers._cmaes",
 )
 
 parser = argparse.ArgumentParser()
@@ -37,8 +38,9 @@ def create_cmaes_study(seed):
 
 
 def create_sep_cmaes_study(seed):
-    optuna.samplers._cmaes.CMA = SepCMA  # monkey patch
-    sampler = optuna.samplers.CmaEsSampler(seed=seed, warn_independent_sampling=True)
+    sampler = optuna.samplers.CmaEsSampler(
+        seed=seed, warn_independent_sampling=True, use_separable_cma=True
+    )
     return optuna.create_study(sampler=sampler, pruner=optuna.pruners.NopPruner())
 
 
@@ -53,12 +55,12 @@ def create_ipop_cmaes_study(seed):
 
 
 def create_ipop_sep_cmaes_study(seed):
-    optuna.samplers._cmaes.CMA = SepCMA  # monkey patch
     sampler = optuna.samplers.CmaEsSampler(
         seed=seed,
         warn_independent_sampling=True,
         restart_strategy="ipop",
         inc_popsize=2,
+        use_separable_cma=True,
     )
     return optuna.create_study(sampler=sampler, pruner=optuna.pruners.NopPruner())
 

--- a/benchmark/optuna_solver.py
+++ b/benchmark/optuna_solver.py
@@ -7,14 +7,13 @@ from kurobako import solver
 from kurobako.solver.optuna import OptunaSolverFactory
 
 warnings.filterwarnings(
-    "default",
-    category=optuna.exceptions.ExperimentalWarning,
-    module="optuna.samplers"
+    "default", category=optuna.exceptions.ExperimentalWarning, module="optuna.samplers"
 )
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "sampler", choices=["cmaes", "sep-cmaes", "ipop-cmaes", "ipop-sep-cmaes", "pycma", "ws-cmaes"]
+    "sampler",
+    choices=["cmaes", "sep-cmaes", "ipop-cmaes", "ipop-sep-cmaes", "pycma", "ws-cmaes"],
 )
 parser.add_argument(
     "--loglevel", choices=["debug", "info", "warning", "error"], default="warning"
@@ -92,7 +91,9 @@ class WarmStartingCmaEsSampler(optuna.samplers.BaseSampler):
         return self._sampler.sample_relative(study, trial, search_space)
 
     def sample_independent(self, study, trial, param_name, param_distribution):
-        return self._sampler.sample_independent(study, trial, param_name, param_distribution)
+        return self._sampler.sample_independent(
+            study, trial, param_name, param_distribution
+        )
 
     def after_trial(
         self,
@@ -109,7 +110,9 @@ class WarmStartingCmaEsSampler(optuna.samplers.BaseSampler):
 
             self._source_trials.append(
                 optuna.create_trial(
-                    params=trial.params, distributions=trial.distributions, values=values
+                    params=trial.params,
+                    distributions=trial.distributions,
+                    values=values,
                 )
             )
         if len(self._source_trials) == self._warm_starting_trials:
@@ -138,7 +141,9 @@ if __name__ == "__main__":
     elif args.sampler == "pycma":
         factory = OptunaSolverFactory(create_pycma_study)
     elif args.sampler == "ws-cmaes":
-        factory = OptunaSolverFactory(create_warm_start_study, warm_starting_trials=args.warm_starting_trials)
+        factory = OptunaSolverFactory(
+            create_warm_start_study, warm_starting_trials=args.warm_starting_trials
+        )
     else:
         raise ValueError("unsupported sampler")
 

--- a/benchmark/optuna_solver.py
+++ b/benchmark/optuna_solver.py
@@ -1,17 +1,25 @@
 import argparse
 import optuna
+import warnings
 
 from cmaes import SepCMA
 from kurobako import solver
 from kurobako.solver.optuna import OptunaSolverFactory
 
+warnings.filterwarnings(
+    "default",
+    category=optuna.exceptions.ExperimentalWarning,
+    module="optuna.samplers"
+)
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "sampler", choices=["cmaes", "sep-cmaes", "ipop-cmaes", "ipop-sep-cmaes", "pycma"]
+    "sampler", choices=["cmaes", "sep-cmaes", "ipop-cmaes", "ipop-sep-cmaes", "pycma", "ws-cmaes"]
 )
 parser.add_argument(
     "--loglevel", choices=["debug", "info", "warning", "error"], default="warning"
 )
+parser.add_argument("--warm-starting-trials", type=int, default=0)
 args = parser.parse_args()
 
 if args.loglevel == "debug":
@@ -64,6 +72,60 @@ def create_pycma_study(seed):
     return optuna.create_study(sampler=sampler, pruner=optuna.pruners.NopPruner())
 
 
+class WarmStartingCmaEsSampler(optuna.samplers.BaseSampler):
+    def __init__(self, seed, warm_starting_trials: int) -> None:
+        self._seed = seed
+        self._warm_starting = True
+        self._warm_starting_trials = warm_starting_trials
+        self._sampler = optuna.samplers.RandomSampler(seed=seed)
+        self._source_trials = []
+
+    def infer_relative_search_space(self, study, trial):
+        return self._sampler.infer_relative_search_space(study, trial)
+
+    def sample_relative(
+        self,
+        study,
+        trial,
+        search_space,
+    ):
+        return self._sampler.sample_relative(study, trial, search_space)
+
+    def sample_independent(self, study, trial, param_name, param_distribution):
+        return self._sampler.sample_independent(study, trial, param_name, param_distribution)
+
+    def after_trial(
+        self,
+        study,
+        trial,
+        state,
+        values,
+    ):
+        if not self._warm_starting:
+            return self._sampler.after_trial(study, trial, state, values)
+
+        if len(self._source_trials) < self._warm_starting_trials:
+            assert state == optuna.trial.TrialState.PRUNED
+
+            self._source_trials.append(
+                optuna.create_trial(
+                    params=trial.params, distributions=trial.distributions, values=values
+                )
+            )
+        if len(self._source_trials) == self._warm_starting_trials:
+            self._sampler = optuna.samplers.CmaEsSampler(
+                seed=self._seed + 1, source_trials=self._source_trials or None
+            )
+            self._warm_starting = False
+        else:
+            return self._sampler.after_trial(study, trial, state, values)
+
+
+def create_warm_start_study(seed):
+    sampler = WarmStartingCmaEsSampler(seed, args.warm_starting_trials)
+    return optuna.create_study(sampler=sampler, pruner=optuna.pruners.NopPruner())
+
+
 if __name__ == "__main__":
     if args.sampler == "cmaes":
         factory = OptunaSolverFactory(create_cmaes_study)
@@ -75,6 +137,8 @@ if __name__ == "__main__":
         factory = OptunaSolverFactory(create_ipop_sep_cmaes_study)
     elif args.sampler == "pycma":
         factory = OptunaSolverFactory(create_pycma_study)
+    elif args.sampler == "ws-cmaes":
+        factory = OptunaSolverFactory(create_warm_start_study, warm_starting_trials=args.warm_starting_trials)
     else:
         raise ValueError("unsupported sampler")
 

--- a/benchmark/runner.sh
+++ b/benchmark/runner.sh
@@ -84,7 +84,7 @@ if [ $WARM_START -gt 0 ]; then
     | $KUROBAKO run --parallelism 6 > $2
 elif [ $BUDGET -le 500 ]; then
   $KUROBAKO studies \
-    --solvers $RANDOM_SOLVER $PYCMA_SOLVER $CMAES_SOLVER $SEP_CMAES_SOLVER \
+    --solvers $SEP_CMAES_SOLVER \
     --problems $PROBLEM \
     --seed $SEED --repeats $REPEATS --budget $BUDGET \
     | $KUROBAKO run --parallelism 4 > $2

--- a/benchmark/runner.sh
+++ b/benchmark/runner.sh
@@ -53,9 +53,9 @@ case "$1" in
         PROBLEM=$($KUROBAKO problem command python $DIR/problem_rastrigin.py $DIM)
         ;;
     toxic-lightgbm)
-        PROBLEM=$(kurobako problem warm-starting \
-            $(kurobako problem surrogate $SURROGATE_ROOT/wscmaes-toxic-source/) \
-            $(kurobako problem surrogate $SURROGATE_ROOT/wscmaes-toxic-target/))
+        PROBLEM=$($KUROBAKO problem warm-starting \
+            $($KUROBAKO problem surrogate $SURROGATE_ROOT/wscmaes-toxic-source/) \
+            $($KUROBAKO problem surrogate $SURROGATE_ROOT/wscmaes-toxic-target/))
         ;;
     help|--help|-h)
         usage

--- a/benchmark/runner.sh
+++ b/benchmark/runner.sh
@@ -76,7 +76,7 @@ IPOP_SEP_CMAES_SOLVER=$($KUROBAKO solver --name 'ipop-sep-cmaes' command -- pyth
 PYCMA_SOLVER=$($KUROBAKO solver --name 'pycma' command -- python $DIR/optuna_solver.py pycma)
 WS_CMAES_SOLVER=$($KUROBAKO solver --name 'ws-cmaes' command -- python $DIR/optuna_solver.py ws-cmaes --warm-starting-trials $WARM_START)
 
-if [ $WARM_START -ge 0 ]; then
+if [ $WARM_START -gt 0 ]; then
   $KUROBAKO studies \
     --solvers $CMAES_SOLVER $WS_CMAES_SOLVER \
     --problems $PROBLEM \

--- a/benchmark/runner.sh
+++ b/benchmark/runner.sh
@@ -84,7 +84,7 @@ if [ $WARM_START -gt 0 ]; then
     | $KUROBAKO run --parallelism 6 > $2
 elif [ $BUDGET -le 500 ]; then
   $KUROBAKO studies \
-    --solvers $SEP_CMAES_SOLVER \
+    --solvers $RANDOM_SOLVER $PYCMA_SOLVER $CMAES_SOLVER $SEP_CMAES_SOLVER \
     --problems $PROBLEM \
     --seed $SEED --repeats $REPEATS --budget $BUDGET \
     | $KUROBAKO run --parallelism 4 > $2

--- a/benchmark/runner.sh
+++ b/benchmark/runner.sh
@@ -24,7 +24,7 @@ Problem:
     himmelblau     : https://en.wikipedia.org/wiki/Himmelblau%27s_function
     ackley         : https://www.sfu.ca/~ssurjano/ackley.html
     rastrigin      : https://www.sfu.ca/~ssurjano/rastr.html
-    toxic-lightgbm : https://www.kaggle.com/peterhurford/lightgbm-with-select-k-best-on-tfidf
+    toxic-lightgbm : https://github.com/c-bata/benchmark-warm-starting-cmaes
 
 Options:
     --help, -h         print this


### PR DESCRIPTION
## Description

We select HPO of LightGBM on Kaggle's Toxic Challenge Dataset as the benchmark problem for Warm Starting CMA-ES (See https://github.com/c-bata/benchmark-warm-starting-cmaes for more details). But this benchmark requires 5-7 days on my Macbook Pro so that it's computationally infeasible to run on GitHub Actions.

Thanks to the amazing work of kurobako by @sile, we can use RF surrogate model to overcome this problem.


## Steps to run kurobako experiment.

1. Download kurobako v0.2.8 CLI.
1. Install Python requirements.
1. Download kurobako surrogate model.
1. Run `WARM_START=100 BUDGET=30 REPEATS=12 SURROGATE_ROOT="./surrogate-models" ./benchmark/runner.sh toxic-lightgbm ./tmp/kurobako.json`
1. `cat ./tmp/kurobako.json | kurobako plot curve --errorbar -o ./tmp`
