### PR TITLE
Set license_file on setup.cfg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ description = Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-E
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = MIT License
+license_file = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
@@ -24,7 +25,6 @@ classifiers =
 
 [options]
 python_requires = >=3.6
-include_package_data = True
 packages = find:
 setup_requires =
     setuptools>=46.4.0


### PR DESCRIPTION
Specify `license_file` in setup.cfg (setuptools 40.8.0+).